### PR TITLE
Allow customDomain === rootDomain.

### DIFF
--- a/app-backend/src/user/ServiceManager.js
+++ b/app-backend/src/user/ServiceManager.js
@@ -362,7 +362,7 @@ class ServiceManager {
                     && (customDomain.length < 80)
                     && /^[a-z0-9\-\.]+$/.test(customDomain)
                     && (customDomain.indexOf('..') < 0)
-                    && (customDomain.indexOf(rootDomain) < 0 || ((customDomain.indexOf(rootDomain) + rootDomain.length) !== customDomain.length));
+                    && (customDomain.indexOf(rootDomain) < 0 || (customDomain === rootDomain) || ((customDomain.indexOf(rootDomain) + rootDomain.length) !== customDomain.length));
 
                 if (!isAllowed) {
                     throw ApiStatusCodes.createError(ApiStatusCodes.STATUS_ERROR_BAD_NAME,


### PR DESCRIPTION
(Thank you so much for this project! I found it today via this Medium post: https://medium.com/@kasra85/how-i-cut-my-heroku-cost-by-400-5b9d0220ce13)

It can be quite useful to have the root domain connected to one of the deployed apps. This PR enables that. Because you can not add an app for the apex domain, this won't conflict with any app names created.

*(As an aside, in the future, I would also rather see it being possible to add any subdomains/hostnames under the root domain as custom domains. That would then require the 'add app' feature and 'add custom domain to app' features to make sure they don't create conflicting names.)*

I have deployed `hugojosefson/captainduckduck:apex` to Docker Hub based on this branch + rename, tried it, and it works. Here's how to test it on a new clean VPS:

1. `mkdir /captain && docker run -v /var/run/docker.sock:/var/run/docker.sock hugojosefson/captainduckduck:apex`
2. In your DNS, you also need to set up a CNAME or A record for the hostname `@`, pointing to the same server.
3. Add any app to your captain.
4. You should now be able to add the root domain as a custom domain to the app.