### PR TITLE
Added proxy_http_version 1.1 to nginx block conf to enable gzipping.

### DIFF
--- a/app-backend/src/template/server-block-conf.ejs
+++ b/app-backend/src/template/server-block-conf.ejs
@@ -58,6 +58,7 @@ if (!s.forceSsl || s.hasSsl) {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
         }
 
         location /.well-known/ {


### PR DESCRIPTION
Nginx gzip only runs if the http version is 1.1.
Nginx proxy default makes the http version to 1.0.

You can change the `gzip_http_version 1.0` in your app, but I think it would be better to make it default to 1.1 with `proxy_http_version 1.1`.